### PR TITLE
Don't trim valid signature bytes during decoding

### DIFF
--- a/lib/serializers/binary.ex
+++ b/lib/serializers/binary.ex
@@ -123,7 +123,7 @@ defmodule Macaroon.Serializers.Binary do
           {%Types.Macaroon{macaroon | public_identifier: id |> String.trim_trailing()}, rest}
 
         "signature " <> sig ->
-          {%Types.Macaroon{macaroon | signature: sig |> String.trim_trailing()}, rest}
+          {%Types.Macaroon{macaroon | signature: binary_part(sig, 0, 32)}, rest}
 
         "cl " <> caveat_location ->
           [vid, id | new_rest] = rest

--- a/test/binary_serializer_test.exs
+++ b/test/binary_serializer_test.exs
@@ -60,5 +60,22 @@ defmodule BinarySerializerTest do
 
       assert {:error, _} = Serializers.Binary.encode(m, :v1)
     end
+
+    test "should not trim off valid signature bytes" do
+      m = Macaroon.create_macaroon(@m_location, @m_id, @m_secret)
+
+      # the last byte of the signature is a whitespace char...
+      m = %{
+        m
+        | signature:
+            <<18, 239, 236, 119, 104, 61, 252, 34, 111, 15, 233, 160, 123, 2, 32, 123, 96, 77,
+              206, 200, 244, 115, 124, 229, 79, 38, 200, 44, 168, 9, 163, 12>>
+      }
+
+      {:ok, encoded_string} = Serializers.Binary.encode(m, :v1)
+
+      decoded = Serializers.Binary.decode(encoded_string, :v1)
+      assert m == decoded
+    end
   end
 end


### PR DESCRIPTION
Using `String.trim_trailing/1` occasionally results in decoded macaroons having invalid signatures if the original signature happened to end in a "whitespace" char, such as `\f` or `\n`. This PR fixes those decoding failures by truncating the decoded signature to the right number of bytes rather than stripping whitespace.